### PR TITLE
separate publication and presentation listings

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,24 @@
+# Table of Contents
+#
+# Myst will respect:
+# 1. New pages
+#      - file: relative/path/to/page
+# 2. New sections without an associated page
+#      - title: Folder Title
+#        sections: ...
+# 3. New sections with an associated page
+#      - file: relative/path/to/page
+#        sections: ...
+#
+# Note: Titles defined on pages here are not recognized.
+#
+# This spec is based on the JupyterBook table of contents.
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: index
+chapters:
+  - file: mission
+  - file: open-science
+  - file: presentations
+  - file: publications

--- a/presentations.md
+++ b/presentations.md
@@ -1,0 +1,12 @@
+---
+title: Presentations
+description: Presentations by the UBC-GIF team
+---
+
+:::{cn:articles}
+:venue: appliedgeophysics
+:collection: presentations
+:show-thumbnails: true
+:show-date: true
+:show-kind: true
+:::

--- a/presentations.md
+++ b/presentations.md
@@ -1,6 +1,8 @@
 ---
 title: Presentations
 description: Presentations by the UBC-GIF team
+options:
+  hide_toc: true
 ---
 
 :::{cn:articles}

--- a/publications.md
+++ b/publications.md
@@ -1,0 +1,12 @@
+---
+title: Publications
+description: Publications by the UBC-GIF team
+---
+
+:::{cn:articles}
+:venue: appliedgeophysics
+:collection: publications
+:show-thumbnails: true
+:show-date: true
+:show-kind: true
+:::

--- a/publications.md
+++ b/publications.md
@@ -1,6 +1,8 @@
 ---
 title: Publications
 description: Publications by the UBC-GIF team
+options:
+  hide_toc: true
 ---
 
 :::{cn:articles}


### PR DESCRIPTION
Added two listing pages and ` _toc.yml`:
![image](https://github.com/ubcgif/appliedgeophysics.org/assets/1473646/44e891df-dd48-4347-bc19-d8b0c8fc1b96)

The site navigation has also been updated but that happens outside of this repo.