### PR TITLE
start an about page

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -18,7 +18,7 @@
 format: jb-book
 root: index
 chapters:
-  - file: mission
+  - file: about
   - file: open-science
   - file: presentations
   - file: publications

--- a/about.md
+++ b/about.md
@@ -1,11 +1,13 @@
 ---
-title: Our Mission and Approach
-subtitle: Advancing applied geophysics
+title: About
+subtitle: Advancing quantitative methods in applied geophysics
 ---
 
-## Our Mission
+The UBC-Geophysical Inversion Facility (UBC-GIF) is an academic research unit within the Department of Earth, Ocean and Atmospheric Sciences ([EOAS](http://eoas.ubc.ca)) at the University of British Columbia ([UBC](https://www.ubc.ca)).
 
-Advance quantitative methods in applied geophysics.
+<!-- ## Our Mission
+
+Advance quantitative methods in applied geophysics. -->
 
 ## Our Approach
 

--- a/index.md
+++ b/index.md
@@ -17,8 +17,8 @@ Data
 Methods
 : Numerical simulations of partial differential equations, optimization techniques, inverse theory, machine learning, open source software.
 
-## AQGeo Consortium
+## Research Consortia
 
 Our research is supported by the Geophysics Inversion Consortium. Our members have access to researchers, private educational materials, and the ability to work with our research group to create research priorities.
 
-[Geophysics Inversion Consortium - Fund I](https://aqgeo.appliedgeophysics.org)
+[Advanced Quantative Geosciences in Mineral Exploration and Mining (AQGeo)](https://aqgeo.appliedgeophysics.org)


### PR DESCRIPTION
I would like to replace the "mission" page with an "about" page. I started making some small edits here. I suspect this will break the "Read our mission" button on the front page, could we swap this for a "About our group"  