### PR TITLE
example listing directives

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,9 +1,27 @@
 ---
-title:
+title: UBC-GIF Research Group
 ---
 
 :::{important} UBC-GIF Research Group
 Our research group advances numerical methods in simulations, inversions, and machine learning. We work on problems in resource exploration, management and environmental applications, foster open science practices, and train the next generation of geoscientists.
+:::
+
+## Latest Papers
+
+:::{cn:articles}
+:venue: appliedgeophysics
+:collection: publications
+:layout: list
+:limit: 3
+:::
+
+## Latest Papers
+
+:::{cn:articles}
+:venue: appliedgeophysics
+:collection: presentations
+:layout: cards
+:limit: 3
 :::
 
 ## Our Focus

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ Our research group advances numerical methods in simulations, inversions, and ma
 :limit: 3
 :::
 
-## Latest Papers
+## Latest Presentations
 
 :::{cn:articles}
 :venue: appliedgeophysics


### PR DESCRIPTION
Towards #13 

@lheagy I have added two `cn:articles` directives to the index page, these will be replaced by listings when deployed that draw from the `presentations` and `publications` collections respectively.

As they are directives you can surround them with content, setup and place them as you see fit.

For more details on the directives you can see the docs here: https://curvenote.com/docs/publish/listings#dynamic-listings

Let me know when you are happy to disable the current listing on the site, maybe before you bring this PR in?